### PR TITLE
add power/voltage setting methods

### DIFF
--- a/korad/kel103.py
+++ b/korad/kel103.py
@@ -65,9 +65,27 @@ class kel103(object):
         s = self.device.udpSendRecv(':MEAS:VOLT?')
         return float(s.strip('V\n'))
     
+    def measureSetVolt(self):
+        s = self.device.udpSendRecv(':VOLT?')
+        return float(s.strip('V\n'))
+
+    def setVolt(self, voltage):
+        s = self.device.udpSend(':VOLT ' + str(voltage) + 'V')
+        if self.measureSetVolt() != voltage:
+            raise ValueError('Voltage set incorectly on the device')
+
     def measurePower(self):
         s = self.device.udpSendRecv(':MEAS:POW?')
         return float(s.strip('W\n'))
+
+    def measureSetPower(self):
+        s = self.device.udpSendRecv(':POW?')
+        return float(s.strip('W\n'))
+
+    def setPower(self, power):
+        s = self.device.udpSend(':POW ' + str(power) + 'W')
+        if self.measureSetPower() != power:
+            raise ValueError('Power set incorectly on the device')
 
     def measureCurrent(self):
         s = self.device.udpSendRecv(':MEAS:CURR?')


### PR DESCRIPTION
Hi @Mango-kid thanks for the work on this repo. It worked pretty well for me! I've added functions to set and query the constant power/voltage modes.

P.s. it was not immediately obvious to me how to enable the LAN interface of the device. I made a companion repo to record some of what I learned. [oclyke-drivers/KEL103](https://github.com/oclyke-drivers/KEL103)